### PR TITLE
fix: prevent dropdown auto-highlight on open

### DIFF
--- a/tauri-app/src/lib/components/NewTaskInput.svelte
+++ b/tauri-app/src/lib/components/NewTaskInput.svelte
@@ -69,11 +69,14 @@
     ).filter((s) => !favouriteNames.has(s.toLowerCase()))
   );
 
+  // Use a value that won't match any item to prevent auto-highlight
+  const NO_SELECTION = "__none__";
+
   $effect(() => {
     if (!open) {
       triggerRef?.blur();
     } else {
-      commandValue = "";
+      commandValue = NO_SELECTION;
     }
   });
 


### PR DESCRIPTION
When opening the task input dropdown, no item is auto-highlighted now. Users must explicitly navigate with arrow keys to select an item.

Fixes #2