### PR TITLE
fix: add CMD+M minimize support for frameless window

### DIFF
--- a/tauri-app/src-tauri/src/lib.rs
+++ b/tauri-app/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 use rusqlite::Connection;
 use std::sync::Mutex;
+use tauri::menu::{MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilder};
 use tauri::Manager;
 
 mod commands;
@@ -21,7 +22,77 @@ pub fn run() {
         .setup(|app| {
             let conn = db::init_db(app.handle())?;
             app.manage(AppState { db: Mutex::new(conn) });
+
+            // Set up macOS menu with Window menu for Minimize support
+            #[cfg(target_os = "macos")]
+            {
+                let app_menu = SubmenuBuilder::new(app, "TimeTracker")
+                    .item(&PredefinedMenuItem::hide(app, Some("Hide TimeTracker"))?)
+                    .item(&PredefinedMenuItem::hide_others(app, None)?)
+                    .item(&PredefinedMenuItem::show_all(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::quit(app, Some("Quit TimeTracker"))?)
+                    .build()?;
+
+                let edit_menu = SubmenuBuilder::new(app, "Edit")
+                    .item(&PredefinedMenuItem::undo(app, None)?)
+                    .item(&PredefinedMenuItem::redo(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::cut(app, None)?)
+                    .item(&PredefinedMenuItem::copy(app, None)?)
+                    .item(&PredefinedMenuItem::paste(app, None)?)
+                    .item(&PredefinedMenuItem::select_all(app, None)?)
+                    .build()?;
+
+                // Use custom menu items with accelerators for window operations
+                // since PredefinedMenuItem doesn't work with frameless windows
+                let minimize_item =
+                    MenuItem::with_id(app, "minimize", "Minimize", true, Some("CmdOrCtrl+M"))?;
+                let zoom_item = MenuItem::with_id(app, "zoom", "Zoom", true, None::<&str>)?;
+                let close_item =
+                    MenuItem::with_id(app, "close", "Close Window", true, Some("CmdOrCtrl+W"))?;
+
+                let window_menu = SubmenuBuilder::new(app, "Window")
+                    .item(&minimize_item)
+                    .item(&zoom_item)
+                    .separator()
+                    .item(&close_item)
+                    .build()?;
+
+                // Mark as the Window menu so macOS adds automatic window items
+                window_menu.set_as_windows_menu_for_nsapp()?;
+
+                let menu = MenuBuilder::new(app)
+                    .item(&app_menu)
+                    .item(&edit_menu)
+                    .item(&window_menu)
+                    .build()?;
+
+                app.set_menu(menu)?;
+            }
+
             Ok(())
+        })
+        .on_menu_event(|app, event| {
+            let id = event.id().as_ref();
+            if let Some(window) = app.get_webview_window("main") {
+                match id {
+                    "minimize" => {
+                        let _ = window.minimize();
+                    }
+                    "zoom" => {
+                        if window.is_maximized().unwrap_or(false) {
+                            let _ = window.unmaximize();
+                        } else {
+                            let _ = window.maximize();
+                        }
+                    }
+                    "close" => {
+                        let _ = window.close();
+                    }
+                    _ => {}
+                }
+            }
         })
         .invoke_handler(tauri::generate_handler![
             // Task commands

--- a/tauri-app/src/lib/hooks/keyboard.svelte.ts
+++ b/tauri-app/src/lib/hooks/keyboard.svelte.ts
@@ -26,6 +26,13 @@ async function handleKeydown(e: KeyboardEvent) {
     return;
   }
 
+  // Cmd/Ctrl+M to minimize window
+  if (modKey && e.key === "m") {
+    e.preventDefault();
+    await minimizeWindow();
+    return;
+  }
+
   // Run any registered custom shortcuts
   for (const { handler } of registeredShortcuts) {
     const handled = await handler(e);
@@ -44,6 +51,14 @@ async function closeWindow() {
   await tracking.stopTracking();
   const currentWindow = getCurrentWindow();
   await currentWindow.close();
+}
+
+/**
+ * Minimize the window
+ */
+async function minimizeWindow() {
+  const currentWindow = getCurrentWindow();
+  await currentWindow.minimize();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds keyboard shortcut handler for CMD+M to minimize the window
- Adds macOS menu bar with TimeTracker, Edit, and Window menus
- Window menu includes Minimize, Zoom, and Close Window items with proper accelerators
- Uses custom menu items with manual event handlers since `PredefinedMenuItem` doesn't work with frameless windows (`decorations: false`)

Fixes #6

## Test plan
- [ ] Press CMD+M to minimize the window
- [ ] Use Window > Minimize menu item
- [ ] Use Window > Zoom menu item
- [ ] Use Window > Close Window menu item
- [ ] Verify Edit menu items work (Copy, Paste, etc.)
- [ ] Verify TimeTracker menu items work (Hide, Quit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)